### PR TITLE
Fix Finviz ticker parsing due to HTML layout changes

### DIFF
--- a/getList_US.py
+++ b/getList_US.py
@@ -72,7 +72,19 @@ for i in range(0, np):
             table_data = []
             for row in rows[1:]:
                 cols = row.find_all('td')
-                cols_text = [col.text.strip() for col in cols]
+                cols_text = []
+                for idx, col in enumerate(cols):
+                    if idx == 1:  # Ticker column
+                        # Find the a tag with class tab-link to get the exact ticker
+                        ticker_a = col.find('a', class_='tab-link')
+                        if ticker_a:
+                            cols_text.append(ticker_a.text.strip())
+                        elif col.has_attr('data-boxover-ticker'):
+                            cols_text.append(col['data-boxover-ticker'].strip())
+                        else:
+                            cols_text.append(col.text.strip())
+                    else:
+                        cols_text.append(col.text.strip())
                 if len(cols_text) == len(headers):
                     table_data.append(cols_text)
 


### PR DESCRIPTION
Finviz has updated its screener table HTML layout for the Ticker column to display inline company logos with a fallback first-letter span. When getList_US.py extracted columns using td.text, it concatenated the fallback span text and the actual ticker, resulting in ticker symbols with a duplicated first letter (e.g. "NNVDA", "AAAPL"). This caused downstream data download failures via yfinance.

This pull request updates getList_US.py to specifically target the <a> tag with class "tab-link" for the Ticker column (idx 1). It also includes a robust fallback using the "data-boxover-ticker" attribute or td.text to guarantee backward-compatibility. Verification confirms that tickers are now parsed perfectly (e.g., "NVDA", "AAPL").

---
*PR created automatically by Jules for task [12171371471641529981](https://jules.google.com/task/12171371471641529981) started by @ikaru-bird*